### PR TITLE
Added a `--dry-run` parameter for the load operation

### DIFF
--- a/bin/route53-transfer
+++ b/bin/route53-transfer
@@ -19,6 +19,7 @@ Options:
   -P --private                            Private Zone
   --vpc-region=VPC_REGION                 Private Zone VPC Region (required for --private, default: $AWS_DEFAULT_REGION)
   --vpc-id=VPC_ID                         Private Zone VPC ID (required for --private)
+  --dry-run                               Perform a dry run when loading. Changes won't be applied.
 """
 
 from docopt import docopt


### PR DESCRIPTION
When `--dry-run` is supplied (and thus `True`), no operation will be carried out. The route53-transfer `load` command will just display the list of operations that would be performed.

Example:

    route53-transfer --dry-run load kahoot.com kahoot.com.csv